### PR TITLE
Fix non-workshop installed mods failing to load.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -227,6 +227,8 @@ if(not failed_to_load)then
 
 			if(item_infos[steam_id])then
 				file_path = item_infos[steam_id].folder
+			else
+				file_path = "mods/" .. mod_id
 			end
 		end
 


### PR DESCRIPTION
If you install the `evaisa.arena` directly in `mods`, the function `GetModFilePath()` returns nil and you cannot load any game modes.

This returns the correct path instead.

Note this is the only change required to get steam lobbies working with SpaceWar ID, similar to Entangled worlds, unsure what else would be needed for GoG users at this point (probably still need a proxy app).

You can launch the steam version via `SteamAppId=480 %command%` to get access to SpaceWar, and edit the `steam_appid.txt` file with `480` as well.

Currently tested this on Linux Steam, but should work fine on Windows.